### PR TITLE
Remove zinc extensions no longer needed

### DIFF
--- a/source/Hyperspace-Model/ZnEntity.extension.st
+++ b/source/Hyperspace-Model/ZnEntity.extension.st
@@ -1,12 +1,6 @@
 Extension { #name : #ZnEntity }
 
 { #category : #'*Hyperspace-Model' }
-ZnEntity class >> json: json [
-
-	^ self stringEntityClass json: json
-]
-
-{ #category : #'*Hyperspace-Model' }
 ZnEntity class >> with: anObject ofType: aMimeType [
 
 	| entity |

--- a/source/Hyperspace-Model/ZnStringEntity.extension.st
+++ b/source/Hyperspace-Model/ZnStringEntity.extension.st
@@ -1,9 +1,0 @@
-Extension { #name : #ZnStringEntity }
-
-{ #category : #'*Hyperspace-Model' }
-ZnStringEntity class >> json: string [
-
-	^ (self type: ZnMimeType applicationJson)
-		string: string;
-		yourself
-]


### PR DESCRIPTION
Because Zinc is now a dependency and already includes the removed methods.