### PR TITLE
Add support for HTTP `QUERY` method

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-There's several ways to contribute to the project: reporting bugs, sending
+There are several ways to contribute to the project: reporting bugs, sending
 feedback, proposing ideas for new features, fixing or adding documentation,
 promoting the project, or even contributing code.
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Building blocks for Internet technologies on top of [Zinc HTTP Components](https
 
 ## Installation
 
-To load the project in a Pharo image follow this [instructions](docs/how-to/how-to-load-in-pharo.md).
+To load the project in a Pharo image follow these [instructions](docs/how-to/how-to-load-in-pharo.md).
 
 ## Contributing
 

--- a/docs/reference/Errors.md
+++ b/docs/reference/Errors.md
@@ -5,7 +5,7 @@
 This is an exception expecting to be raised when someone makes an incorrect HTTP
 request.
 
-It allows to handle any kind of HTTP client errors by doing something like:
+It allows handling any kind of HTTP client errors by doing something like:
 
 ```smalltalk
 [ ... ] on: HTTPClientError do: [:signal | ]
@@ -35,7 +35,7 @@ I represent an HTTP client error: `406 Not Acceptable`
 
 The resource identified by the request is only capable of generating response
 entities that have content characteristics not acceptable according to the
-accept headers sent in the request.
+`Accept` headers sent in the request.
 
  I will carry over information about the acceptable media types.
 
@@ -50,7 +50,7 @@ accept headers sent in the request.
 This is an exception expecting to be raised when the server encounters an
 unexpected error.
 
-It allows to handle any kind of HTTP server errors by doing something like:
+It allows handling any kind of HTTP server errors by doing something like:
 
 ```smalltalk
 [ ... ] on: HTTPServerError do: [:signal | ]

--- a/docs/reference/IETF.md
+++ b/docs/reference/IETF.md
@@ -138,7 +138,7 @@ LanguageRange fromString: 'es-AR'.
 For example:
 
 ```smalltalk
-(LanguangeRage fromString: 'es') matches: 'es-AR' asLanguageTag "==> true"
+(LanguageRange fromString: 'es') matches: 'es-AR' asLanguageTag "==> true"
 ```
 
 **References:**

--- a/docs/reference/Resilience.md
+++ b/docs/reference/Resilience.md
@@ -18,7 +18,7 @@ Retry
  configuredBy: [:retry | "configuration options" ]
 ```
 
-The block to be evaluated can optionally receive the current attempt  number in
+The block to be evaluated can optionally receive the current attempt number in
 a block argument:
 
 ```smalltalk
@@ -32,8 +32,8 @@ Retry
 These options are sent to the `retry` instance provided in the second block.
 
 - `upTo: retryCount` : The maximum number of retries. Defaults to 2.
-- `every: duration` : Wait for a time duration between retry attempts. By
-  default don't wait.
+- `every: duration` : Wait for a time duration between retry attempts. By default,
+  don't wait.
 - `backoffExponentiallyWithTimeSlot: duration` : Wait for a time duration
   between retry attempts determined by using the [exponential backoff algorithm](https://en.wikipedia.org/wiki/Exponential_backoff)
   with a `duration` time slot.

--- a/docs/reference/Zinc.md
+++ b/docs/reference/Zinc.md
@@ -12,9 +12,9 @@
 
 ## ZnUrl
 
-- `queryAt:putUrl:` allows to set a query parameter containing an URL that
+- `queryAt:putUrl:` allows setting a query parameter containing a URL that
   will be URL-encoded
-- `start:limit:` allows to set two query parameters (`start` and `limit`)
+- `start:limit:` allows setting two query parameters (`start` and `limit`)
   usually used in pagination schemes.
 - `asHostedAt:` provides a copy of the URL using as host, scheme, and port
   the ones in the parameter.
@@ -35,6 +35,7 @@
 - `setAccept:` configures the `Accept` header in the current request
 - `setIfMatchTo:` configures the `If-Match` header in the current request
 - `setIfNoneMatchTo:` configures the `If-None-Match` header in the current request
+- `query` adds support for HTTP [QUERY method](https://www.ietf.org/archive/id/draft-ietf-httpbis-safe-method-w-body-02.html)
 
 ## ZnRequest
 
@@ -42,6 +43,7 @@
 - `setAcceptLanguage:` sets the `Accept-Language` header
 - `setIfMatchTo:` configures the `If-Match` header
 - `setIfNoneMatchTo:` configures the `If-None-Match` header
+- `query:` creates an HTTP [QUERY request](https://www.ietf.org/archive/id/draft-ietf-httpbis-safe-method-w-body-02.html)
 
 ## ZnResponse
 

--- a/source/Hyperspace-Model-Tests/ZnClientHyperspaceExtensionsTest.class.st
+++ b/source/Hyperspace-Model-Tests/ZnClientHyperspaceExtensionsTest.class.st
@@ -4,6 +4,36 @@ Class {
 	#category : #'Hyperspace-Model-Tests-Zinc'
 }
 
+{ #category : #private }
+ZnClientHyperspaceExtensionsTest >> handleRequest: request [
+
+	self
+		assert: request method equals: #QUERY;
+		assertUrl: request url equals: 'hello'.
+	^ ZnResponse ok: (ZnEntity text: 'hello')
+]
+
+{ #category : #tests }
+ZnClientHyperspaceExtensionsTest >> testQuery [
+
+	| server port |
+
+	port := self freeListeningTCPPort.
+	server := ZnServer on: port.
+	server delegate: self.
+	server start.
+
+	[
+	| client |
+
+	client := ZnClient new.
+	client url: ('http://localhost:<1p>/hello' expandMacrosWith: port).
+	self
+		assert: client query equals: 'hello';
+		assert: client response isSuccess
+	] ensure: [ server stop ]
+]
+
 { #category : #tests }
 ZnClientHyperspaceExtensionsTest >> testResetRequest [
 

--- a/source/Hyperspace-Model-Tests/ZnRequestHyperspaceExtensionsTest.class.st
+++ b/source/Hyperspace-Model-Tests/ZnRequestHyperspaceExtensionsTest.class.st
@@ -63,6 +63,35 @@ ZnRequestHyperspaceExtensionsTest >> testIfNoneMatch [
 ]
 
 { #category : #tests }
+ZnRequestHyperspaceExtensionsTest >> testQuery [
+
+	| request output |
+
+	request := ZnRequest query: self googleUrl / 'search'.
+
+	self assert: request method equals: #QUERY.
+	output := String streamContents: [ :s | request writeOn: s ].
+
+	self
+		assert: (output includesSubstring: 'QUERY /search HTTP/1.1');
+		assert: (output includesSubstring: 'Host: google.com')
+]
+
+{ #category : #tests }
+ZnRequestHyperspaceExtensionsTest >> testReadQueryRequest [
+
+	| request |
+
+	request := ZnRequest readFrom:
+		           'QUERY /search HTTP/1.1<r><l>Host: google.com' expandMacros readStream.
+
+	self
+		assert: request method equals: #QUERY;
+		assertUrl: request url equals: 'search';
+		assertUrl: request host equals: 'http://google.com'
+]
+
+{ #category : #tests }
 ZnRequestHyperspaceExtensionsTest >> testSetAcceptLanguageWithAny [
 
 	| request |

--- a/source/Hyperspace-Model/ZnClient.extension.st
+++ b/source/Hyperspace-Model/ZnClient.extension.st
@@ -7,6 +7,17 @@ ZnClient >> logLevel [
 ]
 
 { #category : #'*Hyperspace-Model' }
+ZnClient >> query [
+	"Execute an HTTP QUERY the request set up and return the response #contents."
+
+	^ ZnRequest supportQUERYDuring: [
+		  self
+			  method: #QUERY;
+			  execute
+		  ]
+]
+
+{ #category : #'*Hyperspace-Model' }
 ZnClient >> resetRequest [
 
 	request := ZnRequest empty.

--- a/source/Hyperspace-Model/ZnRequest.extension.st
+++ b/source/Hyperspace-Model/ZnRequest.extension.st
@@ -13,6 +13,18 @@ ZnRequest >> hasLanguageProrityList [
 ]
 
 { #category : #'*Hyperspace-Model' }
+ZnRequest class >> query: urlObject [
+
+	^ self supportQUERYDuring: [ self method: #QUERY url: urlObject ]
+]
+
+{ #category : #'*Hyperspace-Model' }
+ZnRequest >> readFrom: stream [
+
+	^ self class supportQUERYDuring: [ super readFrom: stream ]
+]
+
+{ #category : #'*Hyperspace-Model' }
 ZnRequest >> setAcceptLanguage: acceptLanguageDirectives [
 
 	self headers at: 'Accept-Language' put: acceptLanguageDirectives asString
@@ -28,4 +40,12 @@ ZnRequest >> setIfMatchTo: etag [
 ZnRequest >> setIfNoneMatchTo: etag [
 
 	self headers at: 'If-None-Match' put: etag asString
+]
+
+{ #category : #'*Hyperspace-Model' }
+ZnRequest class >> supportQUERYDuring: aBlock [
+
+	^ aBlock
+		  on: ZnUnknownHttpMethod
+		  do: [ :signal | signal resume: signal method ]
 ]


### PR DESCRIPTION
Add support to ZnClient and ZnServer for supporting [QUERY](https://www.ietf.org/archive/id/draft-ietf-httpbis-safe-method-w-body-02.html) as a valid HTTP method.

Fixed some typos in the docs.