### PR TITLE
Support comma-separated directives in Cache-Control header

### DIFF
--- a/source/Hyperspace-Extensions/ZnResponse.extension.st
+++ b/source/Hyperspace-Extensions/ZnResponse.extension.st
@@ -21,12 +21,13 @@ ZnResponse >> addToVary: headerName [
 { #category : '*Hyperspace-Extensions' }
 ZnResponse >> cachingDirectives [
 
-	| directives |
+  | directives |
 
-	directives := self headers at: 'Cache-Control' ifAbsent: [ ^ #() ].
-	^ directives isArray
-		ifTrue: [ directives ]
-		ifFalse: [ Array with: directives ]
+  directives := self headers at: 'Cache-Control' ifAbsent: [ ^ #(  ) ].
+
+  ^ directives isArray
+      ifTrue: [ directives ]
+      ifFalse: [ ( directives substrings: ',' ) collect: #trimBoth ]
 ]
 
 { #category : '*Hyperspace-Extensions' }

--- a/source/Hyperspace-Model-Tests/ZnResponseHyperspaceExtensionsTest.class.st
+++ b/source/Hyperspace-Model-Tests/ZnResponseHyperspaceExtensionsTest.class.st
@@ -73,6 +73,18 @@ ZnResponseHyperspaceExtensionsTest >> testCachingDirectives [
 	self assert: response cachingDirectives equals: #('public' 'Max-Age=60')
 ]
 
+{ #category : 'tests' }
+ZnResponseHyperspaceExtensionsTest >> testCachingDirectivesFromString [
+
+  | response |
+
+  response := ZnResponse noContent.
+
+  response headers at: 'Cache-Control' put: 'public, max-age=60'.
+
+  self assert: response cachingDirectives equals: #( 'public' 'max-age=60' )
+]
+
 { #category : 'tests - encoding' }
 ZnResponseHyperspaceExtensionsTest >> testEncodeAndDecodeWithContentLanguageHeaders [
 


### PR DESCRIPTION
Fix #79 