### PR TITLE
Parse caching directive with multiple arguments properly

### DIFF
--- a/source/Hyperspace-Extensions/ZnResponse.extension.st
+++ b/source/Hyperspace-Extensions/ZnResponse.extension.st
@@ -27,7 +27,7 @@ ZnResponse >> cachingDirectives [
 
   ^ directives isArray
       ifTrue: [ directives ]
-      ifFalse: [ ( directives substrings: ',' ) collect: #trimBoth ]
+      ifFalse: [ (CachingDirectivesParser on: directives readStream) parseDirectives ]
 ]
 
 { #category : '*Hyperspace-Extensions' }

--- a/source/Hyperspace-Extensions/ZnResponse.extension.st
+++ b/source/Hyperspace-Extensions/ZnResponse.extension.st
@@ -22,12 +22,11 @@ ZnResponse >> addToVary: headerName [
 ZnResponse >> cachingDirectives [
 
   | directives |
-
   directives := self headers at: 'Cache-Control' ifAbsent: [ ^ #(  ) ].
 
   ^ directives isArray
       ifTrue: [ directives ]
-      ifFalse: [ (CachingDirectivesParser on: directives readStream) parseDirectives ]
+      ifFalse: [ CachingDirectivesParser new parse: directives ]
 ]
 
 { #category : '*Hyperspace-Extensions' }

--- a/source/Hyperspace-Model-Tests/AbstractCURIETest.class.st
+++ b/source/Hyperspace-Model-Tests/AbstractCURIETest.class.st
@@ -4,8 +4,9 @@ An AbstractCURIETest is a test class for testing the behavior of AbstractCURIE
 Class {
 	#name : 'AbstractCURIETest',
 	#superclass : 'TestCase',
-	#category : 'Hyperspace-Model-Tests',
-	#package : 'Hyperspace-Model-Tests'
+	#category : 'Hyperspace-Model-Tests-IETF',
+	#package : 'Hyperspace-Model-Tests',
+	#tag : 'IETF'
 }
 
 { #category : 'testing' }

--- a/source/Hyperspace-Model-Tests/CURIETest.class.st
+++ b/source/Hyperspace-Model-Tests/CURIETest.class.st
@@ -4,8 +4,9 @@ A CompactURITest is a test class for testing the behavior of CompactURI
 Class {
 	#name : 'CURIETest',
 	#superclass : 'AbstractCURIETest',
-	#category : 'Hyperspace-Model-Tests',
-	#package : 'Hyperspace-Model-Tests'
+	#category : 'Hyperspace-Model-Tests-IETF',
+	#package : 'Hyperspace-Model-Tests',
+	#tag : 'IETF'
 }
 
 { #category : 'private' }

--- a/source/Hyperspace-Model-Tests/SafeCURIETest.class.st
+++ b/source/Hyperspace-Model-Tests/SafeCURIETest.class.st
@@ -4,8 +4,9 @@ A SafeCURIETest is a test class for testing the behavior of SafeCURIE
 Class {
 	#name : 'SafeCURIETest',
 	#superclass : 'AbstractCURIETest',
-	#category : 'Hyperspace-Model-Tests',
-	#package : 'Hyperspace-Model-Tests'
+	#category : 'Hyperspace-Model-Tests-IETF',
+	#package : 'Hyperspace-Model-Tests',
+	#tag : 'IETF'
 }
 
 { #category : 'private' }

--- a/source/Hyperspace-Model-Tests/ZnResponseHyperspaceExtensionsTest.class.st
+++ b/source/Hyperspace-Model-Tests/ZnResponseHyperspaceExtensionsTest.class.st
@@ -108,7 +108,7 @@ ZnResponseHyperspaceExtensionsTest >> testCachingDirectivesWithMalformedDirectiv
 
   response headers at: 'Cache-Control' put: 'private="server, user, max-age=14400'.
 
-  self assert: response cachingDirectives equals: #( 'private="server, user, max-age=14400"' )
+  self assert: response cachingDirectives equals: #( 'private="server, user, max-age=14400' )
 ]
 
 { #category : 'tests' }

--- a/source/Hyperspace-Model-Tests/ZnResponseHyperspaceExtensionsTest.class.st
+++ b/source/Hyperspace-Model-Tests/ZnResponseHyperspaceExtensionsTest.class.st
@@ -85,6 +85,51 @@ ZnResponseHyperspaceExtensionsTest >> testCachingDirectivesFromString [
   self assert: response cachingDirectives equals: #( 'public' 'max-age=60' )
 ]
 
+{ #category : 'tests' }
+ZnResponseHyperspaceExtensionsTest >> testCachingDirectivesWithArrayParameter [
+
+  | response |
+  response := ZnResponse noContent.
+
+  response headers
+    at: 'Cache-Control'
+    put: 'private="server, user", max-age=1440, no-cache="Authorization, Cookie"'.
+
+  self
+    assert: response cachingDirectives
+    equals: #( 'private=server, user' 'max-age=1440' 'no-cache=Authorization, Cookie' )
+]
+
+{ #category : 'tests' }
+ZnResponseHyperspaceExtensionsTest >> testCachingDirectivesWithMalformedDirective [
+
+  | response |
+  response := ZnResponse noContent.
+
+  response headers at: 'Cache-Control' put: 'private="server, user, max-age=14400'.
+
+  self assert: response cachingDirectives equals: #( 'private=server, user, max-age=14400' )
+]
+
+{ #category : 'tests' }
+ZnResponseHyperspaceExtensionsTest >> testCachingDirectivesWithUnknownDirective [
+
+  | response |
+  response := ZnResponse noContent.
+
+  response headers at: 'Cache-Control' put: 'private="server, user", unknown'.
+
+  self assert: response cachingDirectives equals: #( 'private=server, user' unknown ).
+
+  response headers
+    at: 'Cache-Control'
+    put: 'private="server, user", unknown=undefined, max-age=14400'.
+
+  self
+    assert: response cachingDirectives
+    equals: #( 'private=server, user' 'unknown=undefined' 'max-age=14400' )
+]
+
 { #category : 'tests - encoding' }
 ZnResponseHyperspaceExtensionsTest >> testEncodeAndDecodeWithContentLanguageHeaders [
 

--- a/source/Hyperspace-Model-Tests/ZnResponseHyperspaceExtensionsTest.class.st
+++ b/source/Hyperspace-Model-Tests/ZnResponseHyperspaceExtensionsTest.class.st
@@ -97,7 +97,7 @@ ZnResponseHyperspaceExtensionsTest >> testCachingDirectivesWithArrayParameter [
 
   self
     assert: response cachingDirectives
-    equals: #( 'private=server, user' 'max-age=1440' 'no-cache=Authorization, Cookie' )
+    equals: #( 'private="server, user"' 'max-age=1440' 'no-cache="Authorization, Cookie"' )
 ]
 
 { #category : 'tests' }
@@ -108,7 +108,7 @@ ZnResponseHyperspaceExtensionsTest >> testCachingDirectivesWithMalformedDirectiv
 
   response headers at: 'Cache-Control' put: 'private="server, user, max-age=14400'.
 
-  self assert: response cachingDirectives equals: #( 'private=server, user, max-age=14400' )
+  self assert: response cachingDirectives equals: #( 'private="server, user, max-age=14400"' )
 ]
 
 { #category : 'tests' }
@@ -119,7 +119,7 @@ ZnResponseHyperspaceExtensionsTest >> testCachingDirectivesWithUnknownDirective 
 
   response headers at: 'Cache-Control' put: 'private="server, user", unknown'.
 
-  self assert: response cachingDirectives equals: #( 'private=server, user' unknown ).
+  self assert: response cachingDirectives equals: #( 'private="server, user"' unknown ).
 
   response headers
     at: 'Cache-Control'
@@ -127,7 +127,7 @@ ZnResponseHyperspaceExtensionsTest >> testCachingDirectivesWithUnknownDirective 
 
   self
     assert: response cachingDirectives
-    equals: #( 'private=server, user' 'unknown=undefined' 'max-age=14400' )
+    equals: #( 'private="server, user"' 'unknown=undefined' 'max-age=14400' )
 ]
 
 { #category : 'tests - encoding' }

--- a/source/Hyperspace-Model-Tests/ZnResponseHyperspaceExtensionsTest.class.st
+++ b/source/Hyperspace-Model-Tests/ZnResponseHyperspaceExtensionsTest.class.st
@@ -119,7 +119,7 @@ ZnResponseHyperspaceExtensionsTest >> testCachingDirectivesWithUnknownDirective 
 
   response headers at: 'Cache-Control' put: 'private="server, user", unknown'.
 
-  self assert: response cachingDirectives equals: #( 'private="server, user"' unknown ).
+  self assert: response cachingDirectives equals: #( 'private="server, user"' 'unknown' ).
 
   response headers
     at: 'Cache-Control'

--- a/source/Hyperspace-Model/AbstractCURIE.class.st
+++ b/source/Hyperspace-Model/AbstractCURIE.class.st
@@ -1,8 +1,9 @@
 Class {
 	#name : 'AbstractCURIE',
 	#superclass : 'Object',
-	#category : 'Hyperspace-Model',
-	#package : 'Hyperspace-Model'
+	#category : 'Hyperspace-Model-IETF',
+	#package : 'Hyperspace-Model',
+	#tag : 'IETF'
 }
 
 { #category : 'instance creation' }

--- a/source/Hyperspace-Model/CURIE.class.st
+++ b/source/Hyperspace-Model/CURIE.class.st
@@ -11,8 +11,9 @@ Class {
 		'prefix',
 		'relativeReference'
 	],
-	#category : 'Hyperspace-Model',
-	#package : 'Hyperspace-Model'
+	#category : 'Hyperspace-Model-IETF',
+	#package : 'Hyperspace-Model',
+	#tag : 'IETF'
 }
 
 { #category : 'instance creation' }

--- a/source/Hyperspace-Model/CachingDirectivesParser.class.st
+++ b/source/Hyperspace-Model/CachingDirectivesParser.class.st
@@ -1,0 +1,70 @@
+Class {
+	#name : 'CachingDirectivesParser',
+	#superclass : 'Object',
+	#instVars : [
+		'headerStream',
+		'directiveRegistry'
+	],
+	#category : 'Hyperspace-Model',
+	#package : 'Hyperspace-Model'
+}
+
+{ #category : 'instance creation' }
+CachingDirectivesParser class >> on: aReadStream [ 
+	
+	^self new initialize: aReadStream
+]
+
+{ #category : 'adding' }
+CachingDirectivesParser >> consumeSeparators [
+
+  [ ( headerStream peekFor: $, ) or: [ headerStream peekFor: Character space ] ] whileTrue
+]
+
+{ #category : 'initialization' }
+CachingDirectivesParser >> initialize: aReadStream [
+
+  headerStream := aReadStream
+]
+
+{ #category : 'parsing' }
+CachingDirectivesParser >> parseArguments [
+
+  ^ ( headerStream peekFor: $" )
+      then: [ headerStream upTo: $" ]
+      otherwise: [ headerStream upTo: $, ]
+]
+
+{ #category : 'parsing' }
+CachingDirectivesParser >> parseDirectives [
+
+  | directives |
+  directives := OrderedCollection new.
+  [ headerStream atEnd ] whileFalse: [
+      | directive |
+      directive := self parseNextDirective.
+      headerStream peekBack = $=
+        then: [
+            | arguments |
+            arguments := self parseArguments.
+            directives add: ( '<1s>=<2s>' expandMacrosWith: directive with: arguments )
+          ]
+        otherwise: [ directives add: directive ].
+      self consumeSeparators
+    ].
+
+  ^ directives asArray
+]
+
+{ #category : 'parsing' }
+CachingDirectivesParser >> parseNextDirective [
+
+  ^ String streamContents: [ :stream |
+        [ headerStream atEnd or: [ ( headerStream peekFor: $, ) or: [ headerStream peekFor: $= ] ] ]
+          whileFalse: [
+              | char |
+              char := headerStream next.
+              stream nextPut: char
+            ]
+      ]
+]

--- a/source/Hyperspace-Model/CachingDirectivesParser.class.st
+++ b/source/Hyperspace-Model/CachingDirectivesParser.class.st
@@ -3,7 +3,10 @@ Class {
 	#superclass : 'Object',
 	#instVars : [
 		'headerStream',
-		'directiveRegistry'
+		'directiveRegistry',
+		'nextTokenParseMethod',
+		'currentDirective',
+		'directives'
 	],
 	#category : 'Hyperspace-Model',
 	#package : 'Hyperspace-Model'
@@ -24,47 +27,53 @@ CachingDirectivesParser >> consumeSeparators [
 { #category : 'initialization' }
 CachingDirectivesParser >> initialize: aReadStream [
 
-  headerStream := aReadStream
+  headerStream := aReadStream.
+  nextTokenParseMethod := #parseDirective.
+  currentDirective := nil.
+  directives := OrderedCollection new
 ]
 
 { #category : 'parsing' }
 CachingDirectivesParser >> parseArguments [
 
-  ^ ( headerStream peekFor: $" )
-      then: [ '"<1s>"' expandMacrosWith: ( headerStream upTo: $" ) ]
-      otherwise: [ headerStream upTo: $, ]
+  | arguments |
+  arguments := ( headerStream peekFor: $" )
+                 then: [ '"<1s>"' expandMacrosWith: ( headerStream upTo: $" ) ]
+                 otherwise: [ headerStream upTo: $, ].
+
+  directives add: ( '<1s>=<2s>' expandMacrosWith: currentDirective contents with: arguments ).
+
+  nextTokenParseMethod := #parseDirective
+]
+
+{ #category : 'parsing' }
+CachingDirectivesParser >> parseDirective [
+
+  currentDirective := WriteStream on: String new.
+
+  [ headerStream atEnd ] whileFalse: [
+      ( headerStream peekFor: $, ) then: [
+          directives add: currentDirective contents.
+          ^ self
+        ].
+      ( headerStream peekFor: $= ) then: [
+          nextTokenParseMethod := #parseArguments.
+          ^ self
+        ].
+
+      currentDirective nextPut: headerStream next
+    ].
+
+  directives add: currentDirective contents
 ]
 
 { #category : 'parsing' }
 CachingDirectivesParser >> parseDirectives [
 
-  | directives |
-  directives := OrderedCollection new.
   [ headerStream atEnd ] whileFalse: [
-      | directive |
-      directive := self parseNextDirective.
-      headerStream peekBack = $=
-        then: [
-            | arguments |
-            arguments := self parseArguments.
-            directives add: ( '<1s>=<2s>' expandMacrosWith: directive with: arguments )
-          ]
-        otherwise: [ directives add: directive ].
-      self consumeSeparators
+      self consumeSeparators.
+      self perform: nextTokenParseMethod
     ].
 
   ^ directives asArray
-]
-
-{ #category : 'parsing' }
-CachingDirectivesParser >> parseNextDirective [
-
-  ^ String streamContents: [ :stream |
-        [ headerStream atEnd or: [ ( headerStream peekFor: $, ) or: [ headerStream peekFor: $= ] ] ]
-          whileFalse: [
-              | char |
-              char := headerStream next.
-              stream nextPut: char
-            ]
-      ]
 ]

--- a/source/Hyperspace-Model/CachingDirectivesParser.class.st
+++ b/source/Hyperspace-Model/CachingDirectivesParser.class.st
@@ -31,7 +31,7 @@ CachingDirectivesParser >> initialize: aReadStream [
 CachingDirectivesParser >> parseArguments [
 
   ^ ( headerStream peekFor: $" )
-      then: [ headerStream upTo: $" ]
+      then: [ '"<1s>"' expandMacrosWith: ( headerStream upTo: $" ) ]
       otherwise: [ headerStream upTo: $, ]
 ]
 

--- a/source/Hyperspace-Model/CachingDirectivesParser.class.st
+++ b/source/Hyperspace-Model/CachingDirectivesParser.class.st
@@ -1,15 +1,9 @@
 Class {
 	#name : 'CachingDirectivesParser',
 	#superclass : 'Object',
-	#instVars : [
-		'headerStream',
-		'directiveRegistry',
-		'nextTokenParseMethod',
-		'currentDirective',
-		'directives'
-	],
-	#category : 'Hyperspace-Model',
-	#package : 'Hyperspace-Model'
+	#category : 'Hyperspace-Model-IETF',
+	#package : 'Hyperspace-Model',
+	#tag : 'IETF'
 }
 
 { #category : 'instance creation' }
@@ -18,71 +12,33 @@ CachingDirectivesParser class >> on: aReadStream [
 	^self new initialize: aReadStream
 ]
 
-{ #category : 'private - parsing' }
-CachingDirectivesParser >> consumeSeparators [
-
-  [ ( headerStream peekFor: $, ) or: [ headerStream peekFor: Character space ] ] whileTrue
-]
-
-{ #category : 'initialization' }
-CachingDirectivesParser >> initialize: aReadStream [
-
-  headerStream := aReadStream.
-  nextTokenParseMethod := #parseDirective.
-  currentDirective := nil.
-  directives := OrderedCollection new
-]
-
-{ #category : 'private - parsing' }
-CachingDirectivesParser >> parseArguments [
-
-  | arguments |
-  arguments := ( headerStream peekFor: $" )
-                 then: [ '"<1s>"' expandMacrosWith: ( headerStream upTo: $" ) ]
-                 otherwise: [ headerStream upTo: $, ].
-
-  currentDirective
-    nextPut: $=;
-    nextPutAll: arguments.
-
-  self storeCurrentDirective.
-
-  nextTokenParseMethod := #parseDirective
-]
-
-{ #category : 'private - parsing' }
-CachingDirectivesParser >> parseDirective [
-
-  currentDirective := WriteStream on: String new.
-
-  [ headerStream atEnd ] whileFalse: [
-      ( headerStream peekFor: $, ) then: [
-          self storeCurrentDirective.
-          ^ self
-        ].
-      ( headerStream peekFor: $= ) then: [
-          nextTokenParseMethod := #parseArguments.
-          ^ self
-        ].
-
-      currentDirective nextPut: headerStream next
-    ].
-  self storeCurrentDirective
-]
-
 { #category : 'parsing' }
-CachingDirectivesParser >> parseDirectives [
+CachingDirectivesParser >> parse: string [
 
-  [ headerStream atEnd ] whileFalse: [
-      self consumeSeparators.
-      self perform: nextTokenParseMethod
+  | readStream directives isInsideQuotes currentDirectiveStream |
+  directives := OrderedCollection new.
+  isInsideQuotes := false.
+  currentDirectiveStream := String new writeStream.
+  readStream := string readStream.
+  [ readStream atEnd ] whileFalse: [
+      | nextCharacter |
+      nextCharacter := readStream next.
+      nextCharacter = $,
+        then: [
+            isInsideQuotes
+              then: [ "Inside quotes keeps processing, do not use as separator"
+                  currentDirectiveStream nextPut: nextCharacter ]
+              otherwise: [ "Outside quotes use a directive separator"
+                  directives add: currentDirectiveStream contents trimBoth.
+                  currentDirectiveStream := String new writeStream
+                ]
+          ]
+        otherwise: [
+            nextCharacter = $" then: [ isInsideQuotes := isInsideQuotes not ].
+            currentDirectiveStream nextPut: nextCharacter
+          ]
     ].
-
+  "Process any remaining part of the input"
+  currentDirectiveStream contents trimBoth ifNotEmpty: [ :directive | directives add: directive ].
   ^ directives asArray
-]
-
-{ #category : 'private - parsing' }
-CachingDirectivesParser >> storeCurrentDirective [
-
-  directives add: currentDirective contents
 ]

--- a/source/Hyperspace-Model/CachingDirectivesParser.class.st
+++ b/source/Hyperspace-Model/CachingDirectivesParser.class.st
@@ -6,12 +6,6 @@ Class {
 	#tag : 'IETF'
 }
 
-{ #category : 'instance creation' }
-CachingDirectivesParser class >> on: aReadStream [ 
-	
-	^self new initialize: aReadStream
-]
-
 { #category : 'parsing' }
 CachingDirectivesParser >> parse: string [
 

--- a/source/Hyperspace-Model/CachingDirectivesParser.class.st
+++ b/source/Hyperspace-Model/CachingDirectivesParser.class.st
@@ -18,7 +18,7 @@ CachingDirectivesParser class >> on: aReadStream [
 	^self new initialize: aReadStream
 ]
 
-{ #category : 'adding' }
+{ #category : 'private - parsing' }
 CachingDirectivesParser >> consumeSeparators [
 
   [ ( headerStream peekFor: $, ) or: [ headerStream peekFor: Character space ] ] whileTrue
@@ -33,7 +33,7 @@ CachingDirectivesParser >> initialize: aReadStream [
   directives := OrderedCollection new
 ]
 
-{ #category : 'parsing' }
+{ #category : 'private - parsing' }
 CachingDirectivesParser >> parseArguments [
 
   | arguments |
@@ -41,19 +41,23 @@ CachingDirectivesParser >> parseArguments [
                  then: [ '"<1s>"' expandMacrosWith: ( headerStream upTo: $" ) ]
                  otherwise: [ headerStream upTo: $, ].
 
-  directives add: ( '<1s>=<2s>' expandMacrosWith: currentDirective contents with: arguments ).
+  currentDirective
+    nextPut: $=;
+    nextPutAll: arguments.
+
+  self storeCurrentDirective.
 
   nextTokenParseMethod := #parseDirective
 ]
 
-{ #category : 'parsing' }
+{ #category : 'private - parsing' }
 CachingDirectivesParser >> parseDirective [
 
   currentDirective := WriteStream on: String new.
 
   [ headerStream atEnd ] whileFalse: [
       ( headerStream peekFor: $, ) then: [
-          directives add: currentDirective contents.
+          self storeCurrentDirective.
           ^ self
         ].
       ( headerStream peekFor: $= ) then: [
@@ -63,8 +67,7 @@ CachingDirectivesParser >> parseDirective [
 
       currentDirective nextPut: headerStream next
     ].
-
-  directives add: currentDirective contents
+  self storeCurrentDirective
 ]
 
 { #category : 'parsing' }
@@ -76,4 +79,10 @@ CachingDirectivesParser >> parseDirectives [
     ].
 
   ^ directives asArray
+]
+
+{ #category : 'private - parsing' }
+CachingDirectivesParser >> storeCurrentDirective [
+
+  directives add: currentDirective contents
 ]

--- a/source/Hyperspace-Model/SafeCURIE.class.st
+++ b/source/Hyperspace-Model/SafeCURIE.class.st
@@ -11,8 +11,9 @@ Class {
 	#instVars : [
 		'curie'
 	],
-	#category : 'Hyperspace-Model',
-	#package : 'Hyperspace-Model'
+	#category : 'Hyperspace-Model-IETF',
+	#package : 'Hyperspace-Model',
+	#tag : 'IETF'
 }
 
 { #category : 'instance creation' }

--- a/source/Hyperspace-Model/ZnEventToLogRecordAdapter.class.st
+++ b/source/Hyperspace-Model/ZnEventToLogRecordAdapter.class.st
@@ -6,8 +6,9 @@ Class {
 		'logIncomingRequests',
 		'subscriptions'
 	],
-	#category : 'Hyperspace-Model',
-	#package : 'Hyperspace-Model'
+	#category : 'Hyperspace-Model-Resilience',
+	#package : 'Hyperspace-Model',
+	#tag : 'Resilience'
 }
 
 { #category : 'private - dumping' }


### PR DESCRIPTION
According to the [RFC9111](https://httpwg.org/specs/rfc9111.html#field.cache-control), directive can have quoted strings as parameters. This MR add support for them. 